### PR TITLE
Improve crawl resilience and company storage naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Finder.fi Industry Crawler
 
-This project provides a stealthy web crawler that extracts industry and company information from [Finder.fi](https://www.finder.fi/toimialat). It leverages Playwright with headless Chromium to solve the AWS WAF JavaScript challenge and reads the structured `__NEXT_DATA__` payloads rendered by the site.
+This project provides a stealthy web crawler that extracts industry and company information from [Finder.fi](https://www.finder.fi/toimialat). It leverages Playwright with headless Chromium to solve the AWS WAF JavaScript challenge and reads the structured `__NEXT_DATA__` payloads rendered by the site. The crawler is optimised for marathon-style runs that can span hours or days while staying below Cloudflare rate limits and while keeping progress checkpoints on disk.
 
 ## Features
 - Discover industries via the `toimialat` index.
-- Iterate paginated search results for each industry (15 results per page) with configurable limits.
+- Iterate paginated search results for each industry (15 results per page) with configurable limits and resumable checkpoints.
 - Fetch detailed company profiles and persist combined search/detail data as JSON for downstream ELT ingestion.
-- Built-in pacing controls, optional industry filters, and headless/non-headless modes.
+- Built-in pacing controls (10–20 seconds between requests by default), optional industry filters, and headless/non-headless modes.
+- Automatic run workspaces (`data/runs/<timestamp>/`) capturing logs, crawl metadata, and resumable progress state.
 
 ## Quick Start
 1. Install dependencies:
@@ -18,9 +19,35 @@ This project provides a stealthy web crawler that extracts industry and company 
    ```bash
    PYTHONPATH=src python -m finder_crawler.cli --industries Agentuuriliike --max-pages 1 --max-companies 3
    ```
-   JSON output will appear under `data/output/<industry>/<company_id>.json` (a sample run is stored under `data/output_sample`).
+   JSON output will appear under `data/runs/<timestamp>/companies/<industry>/<company_name>_<business_id>.json` together with `state.json`, `run_metadata.json`, and log files under `logs/`.
+
+3. Resume a run at any time by pointing the CLI to the previous workspace (absolute path or relative to `--output-root`):
+
+   ```bash
+   PYTHONPATH=src python -m finder_crawler.cli --resume data/runs/20240205_120000
+   ```
+
+   The crawler continues from the recorded page/index for each industry while skipping company detail requests that already exist on disk.
+
+## Full dataset crawl
+
+To crawl every available company across all Finder.fi industries in one continuous run, invoke the CLI with the `--full-run` flag. This clears any per-industry filters or page/company limits so the crawler keeps going until the catalog is exhausted:
+
+```bash
+PYTHONPATH=src python -m finder_crawler.cli --full-run --min-delay 12 --max-delay 28
+```
+
+* A new timestamped workspace (e.g. `data/runs/20240205_235959/`) is created automatically with logs, metadata, and resumable `state.json` checkpoints.
+* If the process is interrupted, restart it with `--resume` pointing to the workspace directory to continue where it left off.
+* Adjust the delay bounds to tune pacing for your environment—longer delays (e.g. 15–30 seconds) further reduce the likelihood of triggering Cloudflare rate limiting during a multi-day crawl.
 
 Use `python -m finder_crawler.cli --help` to view all options.
 
-> **Note:** Crawling the entire dataset requires a significant number of requests (thousands per industry). Adjust limits responsibly and consider pausing between runs to stay stealthy.
+> **Note:** Crawling the entire dataset still requires a significant number of requests (thousands per industry). Keep the generous default pacing or slow it down further with `--min-delay`/`--max-delay`, and consider distributing work across multiple days.
+
+## Observability and resilience
+
+- Every company write is logged to `logs/crawl.log`, including the Finder detail URL being fetched.
+- Failed fetches are automatically retried up to three times with back-off; exhausted attempts are recorded in `logs/failed_companies.log` for later review.
+- Output filenames combine a normalised company name and the Finder business identifier (e.g. `acme_oy_1234567-8.json`). Duplicate combinations receive a numeric suffix to stay unique.
 

--- a/src/finder_crawler/cli.py
+++ b/src/finder_crawler/cli.py
@@ -10,13 +10,34 @@ from .crawler import configure_logging, run
 
 def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Finder.fi industry/company crawler")
-    parser.add_argument("--output-dir", type=Path, default=Path("data/output"), help="Directory for JSON output")
+    parser.add_argument(
+        "--output-root",
+        "--output-dir",
+        dest="output_root",
+        type=Path,
+        default=Path("data/runs"),
+        help="Base directory where timestamped crawl runs will be stored",
+    )
     parser.add_argument("--industries", nargs="*", help="Optional list of industry names to crawl (case-insensitive)")
-    parser.add_argument("--max-pages", type=int, default=1, help="Maximum pages per industry (default: 1 for safety)")
+    parser.add_argument("--max-pages", type=int, default=None, help="Maximum pages per industry (default: crawl all)")
     parser.add_argument("--max-companies", type=int, default=None, help="Optional cap on companies per industry")
     parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=True, help="Run browser in headless mode")
-    parser.add_argument("--min-delay", type=float, default=1.5, help="Minimum delay between requests (seconds)")
-    parser.add_argument("--max-delay", type=float, default=3.5, help="Maximum delay between requests (seconds)")
+    parser.add_argument("--min-delay", type=float, default=10.0, help="Minimum delay between requests (seconds)")
+    parser.add_argument("--max-delay", type=float, default=20.0, help="Maximum delay between requests (seconds)")
+    parser.add_argument("--run-id", type=str, default=None, help="Optional custom identifier for the crawl run directory")
+    parser.add_argument(
+        "--resume",
+        type=Path,
+        default=None,
+        help="Resume from an existing run directory (absolute or relative to output root)",
+    )
+    parser.add_argument(
+        "--full-run",
+        action="store_true",
+        help=(
+            "Ignore industry/page/company limits and crawl the complete Finder.fi dataset in a single run"
+        ),
+    )
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
     return parser.parse_args(argv)
 
@@ -24,14 +45,27 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
 def main(argv: Iterable[str] | None = None) -> None:
     args = parse_args(argv)
     configure_logging(args.verbose)
+    industries_filter = args.industries or None
+    max_pages = args.max_pages if args.max_pages and args.max_pages > 0 else None
+    max_companies = (
+        args.max_companies if args.max_companies and args.max_companies > 0 else None
+    )
+
+    if args.full_run:
+        industries_filter = None
+        max_pages = None
+        max_companies = None
+
     config = CrawlConfig(
-        output_dir=args.output_dir,
+        output_dir=args.output_root,
         headless=args.headless,
         min_delay_seconds=args.min_delay,
         max_delay_seconds=args.max_delay,
-        industries_filter=args.industries or None,
-        max_pages_per_industry=args.max_pages if args.max_pages and args.max_pages > 0 else None,
-        max_companies_per_industry=args.max_companies if args.max_companies and args.max_companies > 0 else None,
+        industries_filter=industries_filter,
+        max_pages_per_industry=max_pages,
+        max_companies_per_industry=max_companies,
+        run_id=args.run_id,
+        resume_from=args.resume,
     )
     result = run(config)
     print(
@@ -40,6 +74,7 @@ def main(argv: Iterable[str] | None = None) -> None:
             "industries": result.industries,
             "companies": result.companies_written,
             "pages": result.pages_visited,
+            "failed": result.failed_companies,
         },
     )
 

--- a/src/finder_crawler/company.py
+++ b/src/finder_crawler/company.py
@@ -26,8 +26,10 @@ class CompanyDetailFetcher:
         company_name: str,
         city: Optional[str],
         category: str,
+        *,
+        detail_url: Optional[str] = None,
     ) -> CompanyDetail:
-        url = build_company_detail_url(category or industry, company_name, city, company_id)
+        url = detail_url or build_company_detail_url(category or industry, company_name, city, company_id)
         data = await self._session.goto(url)
         state = data["props"]["pageProps"]["dehydratedState"]["queries"][0]["state"]["data"]
         return CompanyDetail(

--- a/src/finder_crawler/config.py
+++ b/src/finder_crawler/config.py
@@ -16,16 +16,23 @@ DEFAULT_USER_AGENT = (
 class CrawlConfig:
     """Runtime configuration for the Finder.fi crawler."""
 
-    output_dir: Path = Path("data/output")
+    output_dir: Path = Path("data/runs")
     headless: bool = True
-    min_delay_seconds: float = 1.5
-    max_delay_seconds: float = 3.5
+    min_delay_seconds: float = 10.0
+    max_delay_seconds: float = 20.0
     navigation_timeout_ms: int = 45_000
     user_agent: str = DEFAULT_USER_AGENT
     industries_filter: Optional[Iterable[str]] = None
     max_pages_per_industry: Optional[int] = None
     max_companies_per_industry: Optional[int] = None
     persist_raw_search: bool = False
+    run_id: Optional[str] = None
+    resume_from: Optional[Path] = None
+    max_detail_retries: int = 3
+    retry_backoff_seconds: float = 60.0
+    failure_spike_threshold: int = 5
+    failure_backoff_seconds: float = 300.0
+    max_failure_breaks: int = 3
 
     def normalise(self) -> "CrawlConfig":
         self.output_dir = Path(self.output_dir)
@@ -35,6 +42,11 @@ class CrawlConfig:
                 self.max_delay_seconds,
                 self.min_delay_seconds,
             )
+        self.max_detail_retries = max(1, int(self.max_detail_retries))
+        self.retry_backoff_seconds = max(0.0, float(self.retry_backoff_seconds))
+        self.failure_spike_threshold = max(1, int(self.failure_spike_threshold))
+        self.failure_backoff_seconds = max(0.0, float(self.failure_backoff_seconds))
+        self.max_failure_breaks = max(0, int(self.max_failure_breaks))
         return self
 
 
@@ -46,4 +58,5 @@ class RunMetadata:
     total_companies: int = 0
     pages_visited: int = 0
     companies_written: int = 0
+    failed_companies: int = 0
 

--- a/src/finder_crawler/crawler.py
+++ b/src/finder_crawler/crawler.py
@@ -2,76 +2,312 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections import deque
+from typing import Any, Mapping, Optional
 
 from .browser import BrowserSession
 from .company import CompanyDetailFetcher
 from .config import CrawlConfig, RunMetadata
 from .industries import iter_industry_names
 from .search import SearchCrawler
+from .state import RunState, RunWorkspace
 from .storage import CompanyRecord, JsonStorage
-from .utils import timestamp_utc
+from .utils import build_company_detail_url, timestamp_utc, write_json
 
 
 logger = logging.getLogger(__name__)
 
 
+class FailureTracker:
+    """Track repeated failures and enforce back-off / abort semantics."""
+
+    def __init__(self, threshold: int, backoff_seconds: float, max_breaks: int) -> None:
+        self._threshold = max(1, threshold)
+        self._backoff_seconds = max(0.0, backoff_seconds)
+        self._max_breaks = max(0, max_breaks)
+        self._recent: deque[str] = deque(maxlen=self._threshold)
+        self.total_failures = 0
+        self._breaks_taken = 0
+
+    def record_success(self) -> None:
+        self._recent.clear()
+
+    async def record_failure(self, company_key: str) -> bool:
+        """Register a failure and decide whether the crawl may continue.
+
+        Returns ``False`` when the crawl should be halted because repeated
+        failures persisted through the configured number of back-off cycles.
+        """
+
+        self.total_failures += 1
+        self._recent.append(company_key)
+        if len(self._recent) < self._threshold:
+            return True
+        if len(set(self._recent)) <= 1:
+            return True
+        if self._breaks_taken >= self._max_breaks:
+            return False
+
+        logger.warning(
+            "Multiple distinct failures detected (%s). Sleeping for %.1f seconds before retrying",
+            list(self._recent),
+            self._backoff_seconds,
+        )
+        if self._backoff_seconds:
+            await asyncio.sleep(self._backoff_seconds)
+        self._breaks_taken += 1
+        self._recent.clear()
+        return True
+
+
+def extract_business_id(payload: Mapping[str, Any]) -> Optional[str]:
+    """Attempt to extract the Finder business identifier from the payload."""
+
+    candidates: list[Mapping[str, Any]] = []
+    for key in ("aiProfile", "company", "basicInformation", "basicInfo"):
+        section = payload.get(key)
+        if isinstance(section, Mapping):
+            candidates.append(section)
+    candidates.append(payload)
+    for section in candidates:
+        for key in ("businessId", "business_id", "yTunnus", "y_tunnus"):
+            value = section.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
 async def run_crawl(config: CrawlConfig) -> RunMetadata:
     config = config.normalise()
+    workspace = RunWorkspace.prepare(config.output_dir, config.run_id, config.resume_from)
+    config.output_dir = workspace.companies_dir
     storage = JsonStorage(config)
+    state = RunState.load(workspace.state_path) if workspace.is_resume else RunState(run_id=workspace.run_id)
     metadata = RunMetadata()
+    failure_tracker = FailureTracker(
+        config.failure_spike_threshold,
+        config.failure_backoff_seconds,
+        config.max_failure_breaks,
+    )
 
-    async with BrowserSession(config) as session:
-        industries = await iter_industry_names(session)
-        if config.industries_filter:
-            allowed = {name.lower() for name in config.industries_filter}
-            industries = [name for name in industries if name.lower() in allowed]
-        metadata.industries = industries
+    file_handler = logging.FileHandler(workspace.logs_dir / "crawl.log")
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+    )
+    root_logger = logging.getLogger()
+    root_logger.addHandler(file_handler)
 
-        search = SearchCrawler(session, config)
-        details = CompanyDetailFetcher(session)
+    logger.info("Starting crawl run %s (resume=%s)", workspace.run_id, workspace.is_resume)
 
-        for industry in industries:
-            logger.info("Processing industry %s", industry)
-            pages_seen = set()
-            async for result in search.iterate_results(industry):
-                pages_seen.add(result.page_number)
-                company_id = result.company_id
-                if not company_id:
-                    logger.warning("Skipping result without company id: %s", result.payload)
-                    continue
-                try:
-                    detail = await details.fetch(
+    try:
+        async with BrowserSession(config) as session:
+            industries = await iter_industry_names(session)
+            if config.industries_filter:
+                allowed = {name.lower() for name in config.industries_filter}
+                industries = [name for name in industries if name.lower() in allowed]
+            state.ensure_industries(industries)
+            state.save(workspace.state_path)
+            metadata.industries = list(state.industries.keys())
+
+            search = SearchCrawler(session, config)
+            details = CompanyDetailFetcher(session)
+            failure_log_path = workspace.logs_dir / "failed_companies.log"
+            stop_requested = False
+
+            for industry in state.remaining_industries():
+                if stop_requested:
+                    break
+                progress = state.industry_progress(industry)
+                logger.info(
+                    "Processing industry %s (starting page %s index %s)",
+                    industry,
+                    progress.next_page,
+                    progress.next_index,
+                )
+                current_page = None
+                async for result in search.iterate_results(
+                    industry,
+                    start_page=progress.next_page,
+                    start_index=progress.next_index,
+                ):
+                    if stop_requested:
+                        break
+                    if current_page != result.page_number:
+                        if current_page is not None:
+                            state.mark_page_complete(industry, current_page)
+                        current_page = result.page_number
+                        state.record_page_visit(industry, current_page)
+                        metadata.pages_visited = state.total_pages_visited
+
+                    company_id = result.company_id
+                    if not company_id:
+                        logger.warning("Skipping result without company id: %s", result.payload)
+                        state.record_company(
+                            industry,
+                            result.page_number,
+                            result.index_on_page,
+                            None,
+                            wrote_to_storage=False,
+                        )
+                        state.save(workspace.state_path)
+                        failure_tracker.record_success()
+                        continue
+
+                    if storage.company_exists(industry, company_id):
+                        logger.debug(
+                            "Company %s already stored, skipping detail fetch",
+                            company_id,
+                        )
+                        state.record_company(
+                            industry,
+                            result.page_number,
+                            result.index_on_page,
+                            company_id,
+                            wrote_to_storage=False,
+                        )
+                        state.save(workspace.state_path)
+                        failure_tracker.record_success()
+                        continue
+
+                    detail_url = build_company_detail_url(
+                        result.category or industry,
+                        result.company_name,
+                        result.city,
+                        company_id,
+                    )
+                    logger.info(
+                        "Crawling company '%s' (%s) from %s page %s index %s -> %s",
+                        result.company_name,
+                        company_id,
+                        industry,
+                        result.page_number,
+                        result.index_on_page,
+                        detail_url,
+                    )
+
+                    detail = None
+                    last_exception: Optional[Exception] = None
+                    for attempt in range(1, config.max_detail_retries + 1):
+                        try:
+                            detail = await details.fetch(
+                                industry=industry,
+                                company_id=company_id,
+                                company_name=result.company_name,
+                                city=result.city,
+                                category=result.category,
+                                detail_url=detail_url,
+                            )
+                            failure_tracker.record_success()
+                            break
+                        except Exception as exc:  # pragma: no cover - network issues
+                            last_exception = exc
+                            logger.exception(
+                                "Attempt %s/%s failed for %s (%s)",
+                                attempt,
+                                config.max_detail_retries,
+                                company_id,
+                                detail_url,
+                            )
+                            if attempt < config.max_detail_retries and config.retry_backoff_seconds:
+                                await asyncio.sleep(config.retry_backoff_seconds)
+
+                    if detail is None:
+                        logger.error(
+                            "Failed to fetch detail for %s after %s attempts", 
+                            company_id,
+                            config.max_detail_retries,
+                        )
+                        failure_line = (
+                            f"{timestamp_utc()} | industry={industry} | page={result.page_number} | "
+                            f"index={result.index_on_page} | company_id={company_id} | "
+                            f"detail_url={detail_url} | error={last_exception!r}"
+                        )
+                        with failure_log_path.open("a", encoding="utf-8") as failure_handle:
+                            failure_handle.write(failure_line + "\n")
+                        state.record_company(
+                            industry,
+                            result.page_number,
+                            result.index_on_page,
+                            company_id,
+                            wrote_to_storage=False,
+                        )
+                        state.save(workspace.state_path)
+                        should_continue = await failure_tracker.record_failure(company_id)
+                        if not should_continue:
+                            logger.error(
+                                "Stopping crawl after repeated failures. See %s for details.",
+                                failure_log_path,
+                            )
+                            stop_requested = True
+                            break
+                        continue
+
+                    business_id = extract_business_id(detail.payload)
+                    if not business_id:
+                        business_id = extract_business_id(result.payload)
+                    storage_id = storage.make_storage_id(
+                        industry,
+                        result.company_name,
+                        business_id,
+                    )
+                    crawled_at = timestamp_utc()
+                    record = CompanyRecord(
                         industry=industry,
                         company_id=company_id,
-                        company_name=result.company_name,
-                        city=result.city,
-                        category=result.category,
+                        storage_id=storage_id,
+                        search_payload=result.payload,
+                        detail_payload=detail.payload,
+                        search_context={
+                            "page": result.page_number,
+                            "index_on_page": result.index_on_page,
+                            "query": result.query_info,
+                        },
+                        metadata={
+                            "industry": industry,
+                            "company_name": result.company_name,
+                            "business_id": business_id,
+                            "storage_id": storage_id,
+                            "crawled_at": crawled_at,
+                            "crawled_url": detail.detail_url,
+                        },
                     )
-                except Exception as exc:  # pragma: no cover - network issues
-                    logger.exception("Failed to fetch detail for %s: %s", company_id, exc)
-                    continue
+                    storage.write_company(record)
+                    metadata.companies_written += 1
+                    state.record_company(
+                        industry,
+                        result.page_number,
+                        result.index_on_page,
+                        company_id,
+                        wrote_to_storage=True,
+                    )
+                    state.save(workspace.state_path)
 
-                record = CompanyRecord(
-                    industry=industry,
-                    company_id=company_id,
-                    search_payload=result.payload,
-                    detail_payload=detail.payload,
-                    search_context={
-                        "page": result.page_number,
-                        "index_on_page": result.index_on_page,
-                        "query": result.query_info,
-                    },
-                    metadata={
-                        "fetched_at": timestamp_utc(),
-                        "detail_url": detail.detail_url,
-                        "industry": industry,
-                    },
-                )
-                storage.write_company(record)
-                metadata.companies_written += 1
-            metadata.pages_visited += len(pages_seen)
-    metadata.total_companies = metadata.companies_written
-    return metadata
+                if stop_requested:
+                    break
+                if current_page is not None:
+                    state.mark_page_complete(industry, current_page)
+                state.mark_industry_complete(industry)
+                state.save(workspace.state_path)
+
+        metadata.total_companies = state.total_companies_written
+        metadata.pages_visited = state.total_pages_visited
+        metadata.failed_companies = failure_tracker.total_failures
+        write_json(
+            workspace.metadata_path,
+            {
+                "run_id": workspace.run_id,
+                "industries": metadata.industries,
+                "companies_written": metadata.companies_written,
+                "pages_visited": metadata.pages_visited,
+                "total_companies": metadata.total_companies,
+                "failed_companies": metadata.failed_companies,
+                "updated_at": timestamp_utc(),
+            },
+        )
+        return metadata
+    finally:
+        root_logger.removeHandler(file_handler)
+        file_handler.close()
 
 
 def configure_logging(verbose: bool = False) -> None:

--- a/src/finder_crawler/search.py
+++ b/src/finder_crawler/search.py
@@ -45,16 +45,24 @@ class SearchCrawler:
         self._session = session
         self._config = config
 
-    async def iterate_results(self, industry: str) -> AsyncIterator[SearchResult]:
+    async def iterate_results(
+        self,
+        industry: str,
+        *,
+        start_page: int = 1,
+        start_index: int = 1,
+    ) -> AsyncIterator[SearchResult]:
         encoded = quote_plus(industry)
-        page = 1
+        page = max(start_page, 1)
         total_pages = None
         yielded = 0
 
         while True:
             if self._config.max_pages_per_industry and page > self._config.max_pages_per_industry:
                 break
-            data = await self._session.goto(f"https://www.finder.fi/search?what={encoded}&page={page}")
+            data = await self._session.goto(
+                f"https://www.finder.fi/search?what={encoded}&page={page}&type=company"
+            )
             query_state = data["props"]["pageProps"]["dehydratedState"]["queries"][0]["state"]
             results: List[Mapping[str, Any]] = query_state["data"]["results"]
             query_info: Dict[str, Any] = dict(query_state["data"].get("query", {}))
@@ -64,6 +72,16 @@ class SearchCrawler:
                 total_pages = math.ceil(total_results / per_page) if per_page else 1
 
             for idx, payload in enumerate(results, start=1):
+                if page == start_page and idx < max(start_index, 1):
+                    continue
+                result_type = str(
+                    payload.get("type")
+                    or payload.get("resultType")
+                    or payload.get("company", {}).get("type")
+                    or "company"
+                ).lower()
+                if result_type != "company" and not payload.get("company"):
+                    continue
                 if self._config.max_companies_per_industry and yielded >= self._config.max_companies_per_industry:
                     return
                 yield SearchResult(

--- a/src/finder_crawler/state.py
+++ b/src/finder_crawler/state.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from datetime import datetime
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+from .utils import ensure_directory, timestamp_utc, write_json
+
+
+@dataclass
+class IndustryProgress:
+    """Track crawl progress for a single industry."""
+
+    name: str
+    next_page: int = 1
+    next_index: int = 1
+    completed: bool = False
+    pages_visited: int = 0
+    last_visited_page: int = 0
+    companies_written: int = 0
+    last_company_id: Optional[str] = None
+
+    def as_dict(self) -> Mapping[str, object]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "IndustryProgress":
+        return cls(
+            name=str(payload.get("name")),
+            next_page=int(payload.get("next_page", 1)),
+            next_index=int(payload.get("next_index", 1)),
+            completed=bool(payload.get("completed", False)),
+            pages_visited=int(payload.get("pages_visited", 0)),
+            companies_written=int(payload.get("companies_written", 0)),
+            last_company_id=(payload.get("last_company_id") or None),
+            last_visited_page=int(payload.get("last_visited_page", 0)),
+        )
+
+
+@dataclass
+class RunState:
+    """Persisted progress for a long running crawl."""
+
+    run_id: str
+    created_at: str = field(default_factory=timestamp_utc)
+    industries: Dict[str, IndustryProgress] = field(default_factory=dict)
+    total_companies_written: int = 0
+    total_pages_visited: int = 0
+
+    @classmethod
+    def initialise(cls, run_id: str, industries: Iterable[str]) -> "RunState":
+        state = cls(run_id=run_id)
+        for name in industries:
+            state.industries[name] = IndustryProgress(name=name)
+        return state
+
+    @classmethod
+    def load(cls, path: Path) -> "RunState":
+        payload = {} if not path.exists() else cls._read_json(path)
+        run_id = str(payload.get("run_id") or path.parent.name)
+        state = cls(run_id=run_id)
+        state.created_at = str(payload.get("created_at", timestamp_utc()))
+        state.total_companies_written = int(payload.get("total_companies_written", 0))
+        state.total_pages_visited = int(payload.get("total_pages_visited", 0))
+        industries_payload = payload.get("industries", {})
+        if isinstance(industries_payload, Mapping):
+            for name, progress_payload in industries_payload.items():
+                if isinstance(progress_payload, Mapping):
+                    state.industries[name] = IndustryProgress.from_dict(progress_payload)
+        return state
+
+    def ensure_industries(self, industries: Iterable[str]) -> None:
+        for name in industries:
+            if name not in self.industries:
+                self.industries[name] = IndustryProgress(name=name)
+
+    def remaining_industries(self) -> List[str]:
+        return [name for name, prog in self.industries.items() if not prog.completed]
+
+    def industry_progress(self, industry: str) -> IndustryProgress:
+        try:
+            return self.industries[industry]
+        except KeyError:  # pragma: no cover - defensive
+            raise KeyError(f"Industry '{industry}' not present in run state")
+
+    def record_page_visit(self, industry: str, page: int) -> None:
+        progress = self.industry_progress(industry)
+        if page != progress.last_visited_page:
+            progress.pages_visited += 1
+            progress.last_visited_page = page
+            self.total_pages_visited += 1
+
+    def record_company(
+        self,
+        industry: str,
+        page: int,
+        index_on_page: int,
+        company_id: Optional[str],
+        wrote_to_storage: bool,
+    ) -> None:
+        progress = self.industry_progress(industry)
+        progress.next_page = page
+        progress.next_index = index_on_page + 1
+        progress.last_company_id = company_id
+        if wrote_to_storage:
+            progress.companies_written += 1
+            self.total_companies_written += 1
+
+    def mark_page_complete(self, industry: str, page: int) -> None:
+        progress = self.industry_progress(industry)
+        if progress.next_page <= page:
+            progress.next_page = page + 1
+            progress.next_index = 1
+
+    def mark_industry_complete(self, industry: str) -> None:
+        progress = self.industry_progress(industry)
+        progress.completed = True
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "run_id": self.run_id,
+            "created_at": self.created_at,
+            "industries": {name: prog.as_dict() for name, prog in self.industries.items()},
+            "total_companies_written": self.total_companies_written,
+            "total_pages_visited": self.total_pages_visited,
+        }
+
+    def save(self, path: Path) -> None:
+        ensure_directory(path.parent)
+        write_json(path, self.to_dict())
+
+    @staticmethod
+    def _read_json(path: Path) -> MutableMapping[str, object]:
+        import json
+
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+
+@dataclass
+class RunWorkspace:
+    """Filesystem layout helper for crawl runs."""
+
+    base_dir: Path
+    run_dir: Path
+    companies_dir: Path
+    logs_dir: Path
+    state_path: Path
+    metadata_path: Path
+    is_resume: bool
+    run_id: str
+
+    @classmethod
+    def prepare(cls, config_output_dir: Path, run_id: Optional[str], resume_from: Optional[Path]) -> "RunWorkspace":
+        ensure_directory(config_output_dir)
+        is_resume = False
+        if resume_from:
+            run_dir = resume_from if resume_from.is_absolute() else config_output_dir / resume_from
+            run_dir = run_dir.resolve()
+            if not run_dir.exists():
+                raise FileNotFoundError(f"Cannot resume crawl; directory not found: {run_dir}")
+            run_id_value = run_dir.name
+            is_resume = True
+        else:
+            run_id_value = run_id or datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+            run_dir = (config_output_dir / run_id_value).resolve()
+            ensure_directory(run_dir)
+
+        companies_dir = run_dir / "companies"
+        logs_dir = run_dir / "logs"
+        state_path = run_dir / "state.json"
+        metadata_path = run_dir / "run_metadata.json"
+
+        ensure_directory(companies_dir)
+        ensure_directory(logs_dir)
+
+        return cls(
+            base_dir=config_output_dir,
+            run_dir=run_dir,
+            companies_dir=companies_dir,
+            logs_dir=logs_dir,
+            state_path=state_path,
+            metadata_path=metadata_path,
+            is_resume=is_resume,
+            run_id=run_id_value,
+        )
+

--- a/src/finder_crawler/storage.py
+++ b/src/finder_crawler/storage.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
+import re
+import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Dict, Mapping, MutableMapping
 
 from .config import CrawlConfig
 from .utils import ensure_directory, write_json
@@ -12,6 +15,7 @@ from .utils import ensure_directory, write_json
 class CompanyRecord:
     industry: str
     company_id: str
+    storage_id: str
     search_payload: Mapping[str, Any]
     detail_payload: Mapping[str, Any]
     search_context: Mapping[str, Any]
@@ -21,6 +25,7 @@ class CompanyRecord:
         return {
             "industry": self.industry,
             "company_id": self.company_id,
+            "storage_id": self.storage_id,
             "search_payload": self.search_payload,
             "detail_payload": self.detail_payload,
             "search_context": self.search_context,
@@ -32,13 +37,79 @@ class JsonStorage:
     def __init__(self, config: CrawlConfig) -> None:
         self._config = config
         ensure_directory(self._config.output_dir)
+        self._index_path = self._config.output_dir / "_index.json"
+        self._index: Dict[str, Dict[str, str]] = self._load_index()
 
-    def company_path(self, industry: str, company_id: str) -> Path:
+    def _load_index(self) -> Dict[str, Dict[str, str]]:
+        if not self._index_path.exists():
+            return {}
+        try:
+            with self._index_path.open("r", encoding="utf-8") as handle:
+                payload: MutableMapping[str, Any] = json.load(handle)
+        except (json.JSONDecodeError, OSError):  # pragma: no cover - defensive
+            return {}
+        result: Dict[str, Dict[str, str]] = {}
+        for industry, mapping in payload.items():
+            if isinstance(mapping, Mapping):
+                result[str(industry)] = {
+                    str(company_id): str(storage_id)
+                    for company_id, storage_id in mapping.items()
+                }
+        return result
+
+    def _save_index(self) -> None:
+        write_json(self._index_path, self._index)
+
+    def company_path(self, industry: str, storage_id: str) -> Path:
         safe_industry = industry.replace("/", "-").replace(" ", "_")
-        return self._config.output_dir / safe_industry / f"{company_id}.json"
+        return self._config.output_dir / safe_industry / f"{storage_id}.json"
+
+    def company_exists(self, industry: str, company_id: str) -> bool:
+        industry_index = self._index.get(industry, {})
+        storage_id = industry_index.get(company_id)
+        if not storage_id:
+            legacy_path = self.company_path(industry, company_id)
+            if legacy_path.exists():
+                industry_index[company_id] = company_id
+                self._index[industry] = industry_index
+                self._save_index()
+                return True
+            return False
+        path = self.company_path(industry, storage_id)
+        if path.exists():
+            return True
+        # Clean up stale index entries if the file disappeared
+        del industry_index[company_id]
+        if not industry_index:
+            self._index.pop(industry, None)
+        self._save_index()
+        return False
 
     def write_company(self, record: CompanyRecord) -> Path:
-        path = self.company_path(record.industry, record.company_id)
+        path = self.company_path(record.industry, record.storage_id)
+        if path.exists():
+            return path
         write_json(path, record.as_dict())
+        industry_index = self._index.setdefault(record.industry, {})
+        industry_index[record.company_id] = record.storage_id
+        self._save_index()
         return path
+
+    def make_storage_id(self, industry: str, company_name: str, business_id: str | None) -> str:
+        name_segment = self._normalise_segment(company_name) or "company"
+        business_segment = self._normalise_segment(business_id or "") or "unknown"
+        base = f"{name_segment}_{business_segment}" if name_segment else business_segment
+        candidate = base or "company"
+        counter = 1
+        while self.company_path(industry, candidate).exists():
+            candidate = f"{base}_{counter}"
+            counter += 1
+        return candidate
+
+    @staticmethod
+    def _normalise_segment(value: str) -> str:
+        value = unicodedata.normalize("NFKD", value.strip().lower())
+        value = "".join(ch for ch in value if not unicodedata.combining(ch))
+        value = re.sub(r"[^a-z0-9]+", "_", value)
+        return value.strip("_")
 


### PR DESCRIPTION
## Summary
- restrict industry searches to company-only results and normalise output filenames to `<company_name>_<business_id>.json`
- add structured logging, retry/backoff handling, and failure tracking so runs persist progress and pause after repeated errors
- capture crawl metadata (URL, timestamp, business id) in each record, maintain a storage index, and document the updated workflow

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d7911f14f48330b6c5043198def4df